### PR TITLE
Hugo-theme-learn : demo should work now

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -115,7 +115,7 @@ blacklist=('persona', 'html5', 'journal', '.git', 'aurora', 'hugo-plus', 'yume',
 # hugo-smpl-theme: Promotional non-Hugo links
 # hugo-theme-learn: the theme owner requested the disable of the theme demo, see https://github.com/gohugoio/hugoThemes/issues/172
 # hugo-finite: Too big
-noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'hugo-theme-learn', 'hugo-finite')
+noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'hugo-finite')
 
 errorCounter=0
 


### PR DESCRIPTION
Modifications have been done in [hugo-theme-learn](https://github.com/matcornic/hugo-theme-learn) and repo should be compatible with automatic demo.