### PR TITLE
Add CircleCI to test build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
         steps:
             - checkout
             - run:
+                name: Checkout submodules
+                command: git submodule update --init
+            - run:
                 name: Install Hugo
                 command: wget https://github.com/gohugoio/hugo/releases/download/v0.32.2/hugo_0.32.2_Linux-64bit.deb -O /tmp/hugo.deb && sudo dpkg -i /tmp/hugo.deb
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2.0
+
+jobs:
+    build:
+        docker:
+            - image: circleci/go:1.8  # This doesn't actually matter
+        steps:
+            - checkout
+            - run:
+                name: Install Hugo
+                command: wget https://github.com/gohugoio/hugo/releases/download/v0.32.2/hugo_0.32.2_Linux-64bit.deb -O /tmp/hugo.deb && sudo dpkg -i /tmp/hugo.deb
+            - run:
+                name: Generate Theme Site
+                command: cd _script && ./generateThemeSite.sh 
+            - run:
+                name: Build Theme Site
+                command: hugo -s _script/hugoThemeSite/themeSite

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.0
 jobs:
     build:
         docker:
-            - image: circleci/go:1.8  # This doesn't actually matter
+            - image: circleci/golang:1.8  # This doesn't actually matter
         steps:
             - checkout
             - run:

--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -119,7 +119,7 @@ noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'hugo-finite'
 
 errorCounter=0
 
-for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -not -path "*_script" | xargs -n1 basename`; do
+for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -not -path "*_script" -not -path "*.circleci" | xargs -n1 basename`; do
 
 
 	blacklisted=`echo ${blacklist[*]} | grep "$x"`


### PR DESCRIPTION
Depends on https://github.com/gohugoio/hugoThemes/issues/319 being fixed, as currently build process doesnt work, CI or otherwise.

This not only enables testing the themes site whenever someone creates a PR. But would also enable people to contribute their own repos directly, instead of relying on creating issues, like https://github.com/gohugoio/hugoThemes/issues/318.

See build log at https://circleci.com/gh/RealOrangeOne/hugoThemes

(Obviously needs CircleCI enabled on this repo!)