### PR TITLE
Remove Hugo Finite Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -292,9 +292,6 @@
 [submodule "hugrid"]
 	path = hugrid
 	url = https://github.com/aerohub/hugrid.git
-[submodule "hugo-finite"]
-	path = hugo-finite
-	url = https://github.com/lambdafu/hugo-finite.git
 [submodule "strange-case"]
 	path = strange-case
 	url = https://github.com/ExchangeRate-API/strange-case.git


### PR DESCRIPTION
The [Hugo Finite Theme](https://themes.gohugo.io/hugo-finite/) has no demo on the Hugo website because it has been [disabled](https://github.com/gohugoio/hugoThemes/blob/master/_script/generateThemeSite.sh#L119) in the Build Script 2 years ago.

Also this theme is unmaintained, its last update was on Jul 29, 2016

Related #430 