### PR TITLE
Remove Hugo Incorporated Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "lanyon"]
 	path = lanyon
 	url = https://github.com/tummychow/lanyon-hugo.git
-[submodule "hugo-incorporated"]
-	path = hugo-incorporated
-	url = https://github.com/nilproductions/hugo-incorporated.git
 [submodule "simple-a"]
 	path = simple-a
 	url = https://github.com/AlexFinn/simple-a.git


### PR DESCRIPTION
The [Hugo Incorporated Theme](https://themes.gohugo.io/hugo-incorporated/) has no demo on the Hugo website because it was [disabled](https://github.com/gohugoio/hugoThemes/blob/master/_script/generateThemeSite.sh#L119) in the Build Script 2 years ago.

However the issue https://github.com/nilproductions/hugo-incorporated/issues/24 that led to this theme being blacklisted was addressed and an Example Site was added. (It seems that somehow the build script was not updated after the issue was resolved).

Unfortunately when I test this theme with the Build Script locally I get the following errors:

```
 ==== PROCESSING  hugo-incorporated  ====== 
Building site for theme hugo-incorporated using its own exampleSite to ../themeSite/static/theme/hugo-incorporated/
ERROR 2018/11/11 23:40:02 render of "home" failed: "/hugoThemes/hugo-incorporated/layouts/index.html:28:13": execute of template failed: template: index.html:35:3: executing "index.html" at <partial "footer.html...>: error calling partial: "/hugoThemes/hugo-incorporated/layouts/partials/footer.html:28:13": execute of template failed: template: partials/footer.html:26:3: executing "partials/footer.html" at <partial "_scripts.ht...>: error calling partial: "/hugoThemes/hugo-incorporated/layouts/partials/_scripts.html:28:13": execute of template failed: template: partials/_scripts.html:28:13: executing "partials/_scripts.html" at <.Site.Params.inc.ana...>: can't evaluate field googleid in type interface {}
ERROR 2018/11/11 23:40:02 render of "page" failed: "/hugoThemes/hugo-incorporated/layouts/_default/single.html:36:21": execute of template failed: template: _default/single.html:36:21: executing "_default/single.html" at <.Site.Params.inc.dis...>: can't evaluate field shortname in type interface {}
FAILED to create exampleSite for hugo-incorporated
```

This theme seems unmaintained to me. Last update was on Sep 22, 2016 and there are 14 open issues (some them are 4 years old).

Related #430 