### PR TITLE
Remove Hugo SMPL Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -331,9 +331,6 @@
 [submodule "blank"]
 	path = blank
 	url = https://github.com/vimux/blank.git
-[submodule "hugo-smpl-theme"]
-	path = hugo-smpl-theme
-	url = https://github.com/christianmendoza/hugo-smpl-theme.git
 [submodule "docuapi"]
 	path = docuapi
 	url = https://github.com/bep/docuapi.git


### PR DESCRIPTION
This closes #311 

The [Hugo SMPL Theme](https://themes.gohugo.io/hugo-smpl-theme/) has no demo on the Hugo website because it has been [disabled](https://github.com/gohugoio/hugoThemes/blob/master/_script/generateThemeSite.sh#L119) in the Build Script 2 years ago.

I haven't got a response from the author about removing the non-Hugo promotional links from the theme's Example Site. See: https://github.com/gohugoio/hugoThemes/issues/311#issuecomment-435346434

Related #430 