### PR TITLE
Remove Hucore Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -436,9 +436,6 @@
 [submodule "hugo-tracks-theme"]
 	path = hugo-tracks-theme
 	url = https://github.com/ageekymonk/hugo-tracks-theme.git
-[submodule "hucore"]
-	path = hucore
-	url = https://github.com/mgjohansen/hucore.git
 [submodule "crab"]
 	path = crab
 	url = https://github.com/thomasheller/crab.git


### PR DESCRIPTION
The [Hucore Theme](https://themes.gohugo.io/hucore/) has no demo generated on the website.

This theme is unmaintained. It was last updated on Jul 3, 2017. 

Currently in the theme's repo there are 6 unaddressed Open GitHub Issues and another 6 Open Pull Requests, all these have been open for months.

Related: #430 

**EDIT**
The error that breaks the demo from the Netlify deploy log:
```
10:09:09 PM:  ==== PROCESSING  hucore  ======
10:09:09 PM: Building site for theme hucore using its own exampleSite to ../themeSite/static/theme/hucore/
10:09:09 PM: Error: Error building site: failed to render pages: render of "home" failed: "/opt/build/repo/hucore/layouts/index.html:1:12": execute of template failed: html/template:index.html:1:12: no such template "theme/_default/list.html"
10:09:09 PM: FAILED to create exampleSite for hucore
```