### PR TITLE
Remove Hemingway2 Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -403,9 +403,6 @@
 [submodule "black-and-light"]
 	path = black-and-light
 	url = https://github.com/davidhampgonsalves/hugo-black-and-light-theme.git
-[submodule "hemingway2"]
-	path = hemingway2
-	url = https://gitlab.com/beli3ver/hemingway2.git
 [submodule "prologue"]
 	path = prologue
 	url = https://github.com/sethmacleod/prologue.git


### PR DESCRIPTION
The [Hemingway2 Theme](https://themes.gohugo.io/hemingway2/) has no demo generated.

This is an unmaintained theme that had its last update on Jul 31, 2017 

Also this theme has wrong installation instructions in its README (there is a 6 month old [open issue](https://gitlab.com/beli3ver/hemingway2/issues/3) about this problem).

Related: #430 

**EDIT**
The ERROR that breaks the demo from the Netlify deploy log:
```
10:09:12 PM:  ==== PROCESSING  hemingway2  ======
10:09:12 PM: Building site for theme hemingway2 using its own exampleSite to ../themeSite/static/theme/hemingway2/
10:09:13 PM: Error: Error building site: failed to render pages: render of "home" failed: "/opt/build/repo/hemingway2/layouts/index.html:1:12": execute of template failed: html/template:index.html:1:12: no such template "theme/_default/list.html"
10:09:13 PM: FAILED to create exampleSite for hemingway2
```