### PR TITLE
Remove Hemingway Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -313,9 +313,6 @@
 [submodule "hugo-faq-theme"]
 	path = hugo-faq-theme
 	url = https://github.com/aerohub/hugo-faq-theme.git
-[submodule "hemingway"]
-	path = hemingway
-	url = https://github.com/tanksuzuki/hemingway.git
 [submodule "hugo-orbit-theme"]
 	path = hugo-orbit-theme
 	url = https://github.com/aerohub/hugo-orbit-theme.git


### PR DESCRIPTION
The [Hemingway Theme](https://themes.gohugo.io/hemingway/) may have its Demo generated but it is an unmaintained theme that had its last update on Nov 11, 2016. 

The reason that this theme needs to be removed is that it outputs invalid HTML. 

There is a long standing [unmerged PR](https://github.com/tanksuzuki/hemingway/pull/14) about this [issue](https://github.com/tanksuzuki/hemingway/issues/13). 

Related: #430 