### PR TITLE
Remove Hugo Smorg Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -590,9 +590,6 @@
 [submodule "hugo-resume"]
 	path = hugo-resume
 	url = https://github.com/eddiewebb/hugo-resume.git
-[submodule "hugo-smorg"]
-	path = hugo-smorg
-	url = https://github.com/solutionroute/hugo-smorg.git
 [submodule "hugo-theme-jane"]
 	path = hugo-theme-jane
 	url = https://github.com/xianmin/hugo-theme-jane.git


### PR DESCRIPTION
The [Hugo Smorg Theme](https://themes.gohugo.io/hugo-smorg/) does not have its demo generated.

There is an [open issue ](https://github.com/solutionroute/hugo-smorg/issues/10) since the 3rd of September about a mediaTypes ERROR. This same ERROR breaks the demo on the Themes website.

This theme had its last update on Apr 27, 2018.

Related: #430 

**EDIT**
The ERROR that breaks the demo from the Netlify deploy log:
```
10:09:09 PM:  ==== PROCESSING  hugo-smorg  ======
10:09:09 PM: Building site for theme hugo-smorg using its own exampleSite to ../themeSite/static/theme/hugo-smorg/
10:09:09 PM: Error: MediaType.Suffix is removed. Before Hugo 0.44 this was used both to set a custom file suffix and as way
10:09:09 PM: to augment the mediatype definition (what you see after the "+", e.g. "image/svg+xml").
10:09:09 PM: This had its limitations. For one, it was only possible with one file extension per MIME type.
10:09:09 PM: Now you can specify multiple file suffixes using "suffixes", but you need to specify the full MIME type
10:09:09 PM: identifier:
10:09:09 PM: [mediaTypes]
10:09:09 PM: [mediaTypes."image/svg+xml"]
10:09:09 PM: suffixes = ["svg", "abc" ]
10:09:09 PM: In most cases, it will be enough to just change:
10:09:09 PM: [mediaTypes]
10:09:09 PM: [mediaTypes."my/custom-mediatype"]
10:09:09 PM: suffix = "txt"
10:09:09 PM: To:
10:09:09 PM: [mediaTypes]
10:09:09 PM: [mediaTypes."my/custom-mediatype"]
10:09:09 PM: suffixes = ["txt"]
10:09:09 PM: Note that you can still get the Media Type's suffix from a template: {{ $mediaType.Suffix }}. But this will now map to the MIME type filename.
10:09:09 PM: FAILED to create exampleSite for hugo-smorg
```


