### PR TITLE
Remove Hugo Crisp Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -103,9 +103,6 @@
 [submodule "simple-hugo"]
 	path = simple-hugo
 	url = https://github.com/druzza/simple-hugo.git
-[submodule "crisp"]
-	path = crisp
-	url = https://github.com/Zenithar/hugo-theme-crisp.git
 [submodule "creative"]
 	path = creative
 	url = https://github.com/digitalcraftsman/hugo-creative-theme.git


### PR DESCRIPTION
The [Hugo Crisp Theme](https://themes.gohugo.io/crisp/) does not have its demo generated on the website.

There is an [open issue](https://github.com/Zenithar/hugo-theme-crisp/issues/9) since March 20, 2018 about `error calling Paginate: Paginators not supported for pages of type "page"`. This same ERROR breaks the theme's demo on the Hugo Themes website.

This theme had its last update on Nov 7, 2017.

Related: #430 

**EDIT**
The ERROR that breaks the demo from the Netlify deploy log:
```
10:10:00 PM:  ==== PROCESSING  crisp  ======
10:10:00 PM: Building site for theme crisp using config "config-crisp.toml" to ../themeSite/static/theme/crisp/
10:10:00 PM: ERROR 2018/11/08 20:10:00 in .Render: Failed to execute template "_default/list.html": "/opt/build/repo/crisp/layouts/_default/list.html:13:33": execute of template failed: template: _default/list.html:13:33: executing "_default/list.html" at <.Paginate>: error calling Paginate: Paginators not supported for pages of type "page" ("Creating a New Theme")
10:10:00 PM: ERROR 2018/11/08 20:10:00 in .Render: Failed to execute template "_default/list.html": "/opt/build/repo/crisp/layouts/_default/list.html:13:33": execute of template failed: template: _default/list.html:13:33: executing "_default/list.html" at <.Paginate>: error calling Paginate: Paginators not supported for pages of type "page" ("Migrate to Hugo from Jekyll")
10:10:00 PM: ERROR 2018/11/08 20:10:00 in .Render: Failed to execute template "_default/list.html": "/opt/build/repo/crisp/layouts/_default/list.html:13:33": execute of template failed: template: _default/list.html:13:33: executing "_default/list.html" at <.Paginate>: error calling Paginate: Paginators not supported for pages of type "page" ("(Hu)go Template Primer")
10:10:00 PM: ERROR 2018/11/08 20:10:00 in .Render: Failed to execute template "_default/list.html": "/opt/build/repo/crisp/layouts/_default/list.html:13:33": execute of template failed: template: _default/list.html:13:33: executing "_default/list.html" at <.Paginate>: error calling Paginate: Paginators not supported for pages of type "page" ("Getting Started with Hugo")
10:10:00 PM: Error: Error building site: logged 4 error(s)
10:10:00 PM: FAILED to create demo site for crisp
```