### PR TITLE
Remove Hugo Bootstrap Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -181,9 +181,6 @@
 [submodule "hugo-minimalist"]
 	path = hugo-minimalist
 	url = https://github.com/digitalcraftsman/hugo-minimalist-theme.git
-[submodule "bootstrap"]
-	path = bootstrap
-	url = https://github.com/mmrath/hugo-bootstrap.git
 [submodule "allegiant"]
 	path = allegiant
 	url = https://github.com/brycematheson/allegiant.git


### PR DESCRIPTION
The [Hugo Bootstrap Theme](https://themes.gohugo.io/bootstrap/) does not have its demo generated on the Themes website.

When the Build Script is executed locally the theme demo breaks due to the following console ERROR: 
``` 
execute of template failed: template: _default/list.html:7:31: executing "_default/list.html" at <.Paginator.Pages>: undefined variable: $index
```

This theme had its last update on Nov 9, 2017.

Related: #430 

**EDIT**
The ERROR that breaks the demo from the Netlify deploy log:
```
10:09:26 PM:  ==== PROCESSING  bootstrap  ======
10:09:26 PM: Building site for theme bootstrap using its own exampleSite to ../themeSite/static/theme/bootstrap/
10:09:26 PM: WARNING: calling IsSet with unsupported type "invalid" (<nil>) will always return false.
10:09:26 PM: ERROR 2018/11/08 20:09:26 render of "taxonomy" failed: "/opt/build/repo/bootstrap/layouts/_default/list.html:7:31": execute of template failed: template: _default/list.html:7:31: executing "_default/list.html" at <.Paginator.Pages>: undefined variable: $index
10:09:26 PM: ERROR 2018/11/08 20:09:26 render of "taxonomy" failed: "/opt/build/repo/bootstrap/layouts/_default/list.html:7:31": execute of template failed: template: _default/list.html:7:31: executing "_default/list.html" at <.Paginator.Pages>: undefined variable: $index
10:09:26 PM: ERROR 2018/11/08 20:09:26 render of "taxonomy" failed: "/opt/build/repo/bootstrap/layouts/_default/list.html:7:31": execute of template failed: template: _default/list.html:7:31: executing "_default/list.html" at <.Paginator.Pages>: undefined variable: $index
10:09:26 PM: ERROR 2018/11/08 20:09:26 render of "taxonomy" failed: "/opt/build/repo/bootstrap/layouts/_default/list.html:7:31": execute of template failed: template: _default/list.html:7:31: executing "_default/list.html" at <.Paginator.Pages>: undefined variable: $index
10:09:26 PM: Error: Error building site: failed to render pages: render of "taxonomy" failed: "/opt/build/repo/bootstrap/layouts/_default/list.html:7:31": execute of template failed: template: _default/list.html:7:31: executing "_default/list.html" at <.Paginator.Pages>: undefined variable: $index
10:09:26 PM: FAILED to create exampleSite for bootstrap
```