### PR TITLE
Remove Internet Weblog Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -226,9 +226,6 @@
 [submodule "material-docs"]
 	path = material-docs
 	url = https://github.com/digitalcraftsman/hugo-material-docs.git
-[submodule "internet-weblog"]
-	path = internet-weblog
-	url = https://github.com/jnjosh/internet-weblog.git
 [submodule "hugo-phlat-theme"]
 	path = hugo-phlat-theme
 	url = https://github.com/nraboy/hugo-phlat-theme.git


### PR DESCRIPTION
The [Internet Weblog Theme](https://themes.gohugo.io/internet-weblog/) does not have its demo generated.

There is an unaddressed [open issue ](https://github.com/jnjosh/internet-weblog/issues/9) since March 20, 2018 about the same ERROR causes a Hugo panic and breaks this theme's demo.

Also this theme had its last update on Feb 3, 2018.