### PR TITLE
Remove Hugo Paper Now

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -382,9 +382,6 @@
 [submodule "mainroad"]
 	path = mainroad
 	url = https://github.com/Vimux/mainroad.git
-[submodule "hugo-paper-now"]
-	path = hugo-paper-now
-	url = https://github.com/eueung/hugo-paper-now.git
 [submodule "hugo-remark-minion"]
 	path = hugo-remark-minion
 	url = https://github.com/eueung/hugo-remark-minion.git


### PR DESCRIPTION
The [Hugo Paper Now Theme](https://themes.gohugo.io/hugo-paper-now/) may have its Demo generated but everything renders blank. 

There is a long standing [open issue](https://github.com/eueung/hugo-paper-now/issues/1) in the theme repo about this problem, the theme author has replied that he [won't fix](https://github.com/eueung/hugo-paper-now/issues/1#issuecomment-354516696) this issue. 

Also this theme's last update was on Dec 18, 2016.

Related: #430 