### PR TITLE
Remove Simple A Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "hugo-incorporated"]
 	path = hugo-incorporated
 	url = https://github.com/nilproductions/hugo-incorporated.git
-[submodule "simple-a"]
-	path = simple-a
-	url = https://github.com/AlexFinn/simple-a.git
 [submodule "journal"]
 	path = journal
 	url = https://github.com/mpas/hugo-journal.git


### PR DESCRIPTION
The [Simple A Theme](https://themes.gohugo.io/simple-a/) does not have a demo because it uses outdated templates that render the Hugo Basic Example blank.

This theme had its last update on Feb 16, 2017

Related: #430 

**EDIT**
Here are the demo breaking errors from the Netlify deploy log:
```
12:14:36 PM:  ==== PROCESSING  simple-a  ======
12:14:36 PM: Building site for theme simple-a using config "config-simple-a.toml" to ../themeSite/static/theme/simple-a/
12:14:37 PM: ERROR 2018/11/09 10:14:36 render of "page" failed: "/opt/build/repo/simple-a/layouts/_default/single.html:26:13": execute of template failed: html/template:_default/single.html:26:13: no such template "theme/chrome/footer.html"
12:14:37 PM: ERROR 2018/11/09 10:14:36 render of "page" failed: "/opt/build/repo/simple-a/layouts/_default/single.html:26:13": execute of template failed: html/template:_default/single.html:26:13: no such template "theme/chrome/footer.html"
12:14:37 PM: ERROR 2018/11/09 10:14:36 render of "page" failed: "/opt/build/repo/simple-a/layouts/_default/single.html:26:13": execute of template failed: html/template:_default/single.html:26:13: no such template "theme/chrome/footer.html"
12:14:37 PM: ERROR 2018/11/09 10:14:36 render of "page" failed: "/opt/build/repo/simple-a/layouts/_default/single.html:26:13": execute of template failed: html/template:_default/single.html:26:13: no such template "theme/chrome/footer.html"
12:14:37 PM: Error: Error building site: failed to render pages: render of "page" failed: "/opt/build/repo/simple-a/layouts/_default/single.html:26:13": execute of template failed: html/template:_default/single.html:26:13: no such template "theme/chrome/footer.html"
12:14:37 PM: FAILED to create demo site for simple-a
```