### PR TITLE
Remove BluestNight theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -472,9 +472,6 @@
 [submodule "osprey"]
 	path = osprey
 	url = https://github.com/tomanistor/osprey.git
-[submodule "BluestNight"]
-	path = BluestNight
-	url = https://gitlab.com/BluestNight/BluestNight.git
 [submodule "slate"]
 	path = slate
 	url = https://github.com/gesquive/slate.git


### PR DESCRIPTION
The [BluestNight Theme](https://themes.gohugo.io/bluestnight/) has no demo on the website.

This theme renders blank when I test it with the Hugo Basic Example. The Themes Build Script only throws WARN and no ERROR but still there is no demo button. 

Also the author has shut down the theme's issue tracker (see: #473 ) 

Related: #430 
This closes #473 

**EDIT**
The deploy log of Netlify shows the following ERROR that is the culprit for the broken demo:
```
12:14:45 PM:  ==== PROCESSING  BluestNight  ======
12:14:45 PM: Building site for theme BluestNight using config "config-BluestNight.toml" to ../themeSite/static/theme/BluestNight/
12:14:45 PM: Error: MediaType.Suffix is removed. Before Hugo 0.44 this was used both to set a custom file suffix and as way
12:14:45 PM: to augment the mediatype definition (what you see after the "+", e.g. "image/svg+xml").
12:14:45 PM: This had its limitations. For one, it was only possible with one file extension per MIME type.
12:14:45 PM: Now you can specify multiple file suffixes using "suffixes", but you need to specify the full MIME type
12:14:45 PM: identifier:
12:14:45 PM: [mediaTypes]
12:14:45 PM: [mediaTypes."image/svg+xml"]
12:14:45 PM: suffixes = ["svg", "abc" ]
12:14:45 PM: In most cases, it will be enough to just change:
12:14:45 PM: [mediaTypes]
12:14:45 PM: [mediaTypes."my/custom-mediatype"]
12:14:45 PM: suffix = "txt"
12:14:46 PM: To:
12:14:46 PM: [mediaTypes]
12:14:46 PM: [mediaTypes."my/custom-mediatype"]
12:14:46 PM: suffixes = ["txt"]
12:14:46 PM: Note that you can still get the Media Type's suffix from a template: {{ $mediaType.Suffix }}. But this will now map to the MIME type filename.
12:14:46 PM: FAILED to create demo site for BluestNight
```