### PR TITLE
Remove Robust Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -124,9 +124,6 @@
 [submodule "material-lite"]
 	path = material-lite
 	url = https://github.com/SamuelDebruyn/hugo-material-lite.git
-[submodule "robust"]
-	path = robust
-	url = https://github.com/dim0627/hugo_theme_robust.git
 [submodule "cactus"]
 	path = cactus
 	url = https://github.com/digitalcraftsman/hugo-cactus-theme.git


### PR DESCRIPTION
The author of the [Robust Theme](https://themes.gohugo.io/robust/) has responded that he no longer uses Hugo and wishes to have the theme removed from the website see: https://github.com/dim0627/hugo_theme_robust/issues/37#issuecomment-437540264

Related #430 