### PR TITLE
Remove Solit Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -310,9 +310,6 @@
 [submodule "hugo-orbit-theme"]
 	path = hugo-orbit-theme
 	url = https://github.com/aerohub/hugo-orbit-theme.git
-[submodule "hugo_theme_solit"]
-	path = hugo_theme_solit
-	url = https://github.com/dim0627/hugo_theme_solit.git
 [submodule "hugo-theme-nix"]
 	path = hugo-theme-nix
 	url = https://github.com/LordMathis/hugo-theme-nix.git


### PR DESCRIPTION
The author of the [Solit Theme](https://themes.gohugo.io/hugo_theme_solit/) has responded that he no longer uses Hugo and wishes to have the theme removed from the website see: https://github.com/dim0627/hugo_theme_solit/issues/9#issuecomment-437540288

Related #430 