### PR TITLE
Remove Aglaus Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,9 +43,6 @@
 [submodule "hugo-base-theme"]
 	path = hugo-base-theme
 	url = https://github.com/crakjie/hugo-base-theme.git
-[submodule "aglaus"]
-	path = aglaus
-	url = https://github.com/dim0627/hugo_theme_aglaus.git
 [submodule "nofancy"]
 	path = nofancy
 	url = https://github.com/gizak/nofancy.git


### PR DESCRIPTION
The author of the [Aglaus Theme](https://themes.gohugo.io/aglaus/) has [responded](https://github.com/dim0627/hugo_theme_aglaus/issues/17#issuecomment-437571589) that he no longer uses Hugo and wishes to have his themes removed from the website see also: 
https://github.com/dim0627/hugo_theme_solit/issues/9#issuecomment-437540288
https://github.com/dim0627/hugo_theme_robust/issues/37#issuecomment-437540264

Related: #430 