### PR TITLE
Add Hugo Bare Min to Build Script noDemo

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -116,7 +116,8 @@ blacklist=('persona', 'html5', 'journal', '.git', 'aurora', 'hugo-plus', 'yume',
 # hugo-theme-learn: the theme owner requested the disable of the theme demo, see https://github.com/gohugoio/hugoThemes/issues/172
 # hugo-finite: Too big
 # lamp: Icon font does not work with baseURL with sub-folder.
-noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'hugo-finite', 'lamp')
+# hugo-bare-min: The demo throws an ERROR because the Build Script does not support Theme Components at the moment, see https://github.com/gohugoio/hugoThemes/issues/463
+noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'hugo-finite', 'lamp', 'hugo-bare-min-theme')
 
 errorCounter=0
 


### PR DESCRIPTION
The demo of the [Hugo Bare Min Theme](https://themes.gohugo.io/hugo-bare-min-theme/) is not generating on the website due to issue #463 

In https://github.com/kaushalmodi/hugo-bare-min-theme/issues/6#issuecomment-437567180 the theme's author agreed to add his theme in the Build Script's noDemo array so that the theme continues to be listed on the Themes website.

This closes: https://github.com/kaushalmodi/hugo-bare-min-theme/issues/6