### PR TITLE
Remove Hyde-X Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 [submodule "liquorice"]
 	path = liquorice
 	url = https://github.com/eliasson/liquorice.git
-[submodule "hyde-x"]
-	path = hyde-x
-	url = https://github.com/zyro/hyde-x.git
 [submodule "purehugo"]
 	path = purehugo
 	url = https://github.com/dplesca/purehugo.git


### PR DESCRIPTION
The [Hyde-X Theme](https://themes.gohugo.io/theme/hyde-x/) has missing assets because the `absURL` function is used incorrectly. 

In the theme's repo  there is PR https://github.com/zyro/hyde-x/pull/79  that [fixes this problem](https://github.com/zyro/hyde-x/pull/79/commits/a7c1a04949d340e6b33815fecf83173581c79b82#diff-35755203408c34159ac6094e42351391) but unfortunately it has been left open since May 7, 2018. 

Also there are another 16 Open Pull Requests and several unaddressed issues. 

This theme looks *unmaintained* to me.

Related: #477 