### PR TITLE
Remove Hurock Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -70,9 +70,6 @@
 [submodule "shiori"]
 	path = shiori
 	url = https://github.com/chibicode/hugo-theme-shiori.git
-[submodule "hurock"]
-	path = hurock
-	url = https://github.com/TiTi/hurock.git
 [submodule "greyshade"]
 	path = greyshade
 	url = https://github.com/cxfksword/greyshade.git


### PR DESCRIPTION
The [Hurock Theme](https://themes.gohugo.io/hurock/) had its last update on Mar 28, 2017. 

This theme relies on the Hugo Basic Example and yet it has a `/content/` directory under its root, within that directory there is only a `shortcodes_samples.md`, as a result there are no posts loading in the demo. 

Also the sidebar points to non existing sections. 

This theme looks *unmaintained* to me.

Related: #477 