### PR TITLE
Whitelist Hugo Finite Theme

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -114,10 +114,9 @@ blacklist=('persona', 'html5', 'journal', '.git', 'aurora', 'hugo-plus', 'yume',
 # hugo-theme-arch: themes generates blank homepage
 # hugo-smpl-theme: Promotional non-Hugo links
 # hugo-theme-learn: the theme owner requested the disable of the theme demo, see https://github.com/gohugoio/hugoThemes/issues/172
-# hugo-finite: Too big
 # lamp: Icon font does not work with baseURL with sub-folder.
 # hugo-bare-min: The demo throws an ERROR because the Build Script does not support Theme Components at the moment, see https://github.com/gohugoio/hugoThemes/issues/463
-noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'hugo-finite', 'lamp', 'hugo-bare-min-theme')
+noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'lamp', 'hugo-bare-min-theme')
 
 errorCounter=0
 


### PR DESCRIPTION
As I said over [here](https://github.com/lambdafu/hugo-finite/issues/3#issuecomment-437695954)

- The Hugo Finite's size was brought down significantly by changing to KaTex.
- The size on disk is now: 37.2 MB down from 77 MB.
 - The new size is comparable to the size of other Hugo Themes that are currently listed on the Hugo website.
- The theme's demo builds fine when I test it locally.

So I am sending this PR to have this theme's demo published on the Hugo website once again.

Related: #430 