### PR TITLE
Remove Bootstrap Premium Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -229,9 +229,6 @@
 [submodule "hugo-darkdoc-theme"]
 	path = hugo-darkdoc-theme
 	url = https://github.com/adejoux/hugo-darkdoc-theme.git
-[submodule "hugo-bootstrap-premium"]
-	path = hugo-bootstrap-premium
-	url = https://github.com/appernetic/hugo-bootstrap-premium.git
 [submodule "academic"]
 	path = academic
 	url = https://github.com/gcushen/hugo-academic.git


### PR DESCRIPTION
The [Hugo Bootstrap Premium Theme](https://themes.gohugo.io/theme/hugo-bootstrap-premium/) demo is without CSS and JS assets.

I opened https://github.com/appernetic/hugo-bootstrap-premium/issues/51 with a fix for the missing Hugo Pipes Assets but I didn't get a reply.

@digitalcraftsman Once this PR is merged I will notify the theme's author about the removal in the issue that I have already opened.

This PR closes #477 