### PR TITLE
Remove Tinyce Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,9 +22,6 @@
 [submodule "purehugo"]
 	path = purehugo
 	url = https://github.com/dplesca/purehugo.git
-[submodule "tinyce"]
-	path = tinyce
-	url = https://github.com/roperzh/tinyce-hugo-theme.git
 [submodule "html5"]
 	path = html5
 	url = https://github.com/simonmika/hugo-theme-html5.git


### PR DESCRIPTION
The [Tinyce Theme](https://themes.gohugo.io/tinyce/) was last updated on Apr 26, 2018.

I opened https://github.com/roperzh/tinyce-hugo-theme/issues/22 with a fix for the missing demo but I didn't get a reply.

@digitalcraftsman Once this PR is merged I will notify the theme's author about the removal in the issue that I have already opened.

Related: #430