### PR TITLE
Remove Hugo Geppaku Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -235,9 +235,6 @@
 [submodule "academic"]
 	path = academic
 	url = https://github.com/gcushen/hugo-academic.git
-[submodule "hugo-theme-geppaku"]
-	path = hugo-theme-geppaku
-	url = https://github.com/masa0221/hugo-theme-geppaku.git
 [submodule "hugo-lithium-theme"]
 	path = hugo-lithium-theme
 	url = https://github.com/jrutheiser/hugo-lithium-theme.git


### PR DESCRIPTION
The [Geppaku Theme](https://themes.gohugo.io/hugo-theme-geppaku/) was last updated on Feb 13, 2017.

I opened https://github.com/masa0221/hugo-theme-geppaku/issues/11 with a fix for the missing demo but I didn't get a reply.

@digitalcraftsman Once this PR is merged I will notify the theme's author about the removal in the issue that I have already opened.

Related: #430