### PR TITLE
Remove Hugo Now Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -451,9 +451,6 @@
 [submodule "manis-hugo-theme"]
 	path = manis-hugo-theme
 	url = https://github.com/yursan9/manis-hugo-theme.git
-[submodule "hugo-now"]
-	path = hugo-now
-	url = https://github.com/mikeblum/hugo-now.git
 [submodule "minimal"]
 	path = minimal
 	url = https://github.com/calintat/minimal.git


### PR DESCRIPTION
The [Hugo Now Theme](https://themes.gohugo.io/hugo-now/) was last updated on Feb 27, 2018.

I opened https://github.com/mikeblum/hugo-now/issues/4 with a fix for the missing demo but I didn't get a reply.

@digitalcraftsman Once this PR is merged I will notify the theme's author about the removal in the issue that I have already opened.

---

This PR clears the [list of Hugo Themes without a working demo](https://github.com/gohugoio/hugoThemes/issues/430#issuecomment-435367441) on the Hugo website (except for the themes by @spf13 and @digitalcraftsman ) and it *finally* closes #430 

Summary
23 themes without a working demo were removed from the Hugo Themes Showcase.
13 themes without a working demo are again functional.

If the theme authors who had their themes removed respond with the appropriate fixes we will be more than happy to have their themes added back to the Themes Showcase.

CC / @bep @felicianotech