### PR TITLE
Re-add Hugo Now Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -783,3 +783,6 @@
 [submodule "infinity-hugo"]
 	path = infinity-hugo
 	url = https://github.com/themefisher/infinity-hugo
+[submodule "hugo-now"]
+	path = hugo-now
+	url = https://github.com/mikeblum/hugo-now.git


### PR DESCRIPTION
The issue that broke this theme's demo is now fixed.

I tested it with the Build Script and everything works fine.

See: https://github.com/mikeblum/hugo-now/issues/4#issuecomment-439723253