### PR TITLE
Remove Simple-A duplicate submodule configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -768,9 +768,6 @@
 [submodule "meghna-hugo"]
 	path = meghna-hugo
 	url = https://github.com/themefisher/meghna-hugo.git
-[submodule "simple-a"]
-	path = simple-a
-	url = https://github.com/AlexFinn/simple-a.git
 [submodule "hurock"]
 	path = hurock
 	url = https://github.com/TiTi/hurock


### PR DESCRIPTION
While updating my fork from the repo I got the following warning:
```
warning: 538f05f731985c1a7fde25a91dc100b983326bd6:.gitmodules, multiple configurations found for 'submodule.simple-a.path'. Skipping second one!
```
It seems that somehow the submodule configuration for the Simple-A theme was entered twice, so I removed the second one and sending this PR to fix this.

**EDIT**
I just saw the comment at https://github.com/AlexFinn/simple-a/issues/7#issuecomment-437824037 but this theme's demo is still not generating see: https://themes.gohugo.io/simple-a/

Here is the deploy log from the Netlify build:
```
4:21:07 PM: ERROR 2018/11/19 14:21:05 render of "page" failed: "/opt/build/repo/simple-a/layouts/_default/single.html:26:13": execute of template failed: html/template:_default/single.html:26:13: no such template "theme/chrome/footer.html"
4:21:08 PM: ERROR 2018/11/19 14:21:05 render of "page" failed: "/opt/build/repo/simple-a/layouts/_default/single.html:26:13": execute of template failed: html/template:_default/single.html:26:13: no such template "theme/chrome/footer.html"
4:21:08 PM: ERROR 2018/11/19 14:21:05 render of "page" failed: "/opt/build/repo/simple-a/layouts/_default/single.html:26:13": execute of template failed: html/template:_default/single.html:26:13: no such template "theme/chrome/footer.html"
4:21:08 PM: ERROR 2018/11/19 14:21:05 render of "page" failed: "/opt/build/repo/simple-a/layouts/_default/single.html:26:13": execute of template failed: html/template:_default/single.html:26:13: no such template "theme/chrome/footer.html"
4:21:08 PM: Error: Error building site: failed to render pages: render of "page" failed: "/opt/build/repo/simple-a/layouts/_default/single.html:26:13": execute of template failed: html/template:_default/single.html:26:13: no such template "theme/chrome/footer.html"
4:21:08 PM: FAILED to create demo site for simple-a
```

**EDIT 2**
It seems that the Simple A theme has been fixed in https://github.com/AlexFinn/simple-a/commit/f42cd781e10712be72ff53e8e5a7ccf485d7e730#diff-1578c58a761c0846adb0e788c860a12bL47 yet the ERROR persists. Maybe the duplicate submodule was causing it not to be updated properly? I am confused... :confused: 