### PR TITLE
Revert "Remove Bootstrap Premium Theme"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -217,6 +217,9 @@
 [submodule "hugo-darkdoc-theme"]
 	path = hugo-darkdoc-theme
 	url = https://github.com/adejoux/hugo-darkdoc-theme.git
+[submodule "hugo-bootstrap-premium"]
+	path = hugo-bootstrap-premium
+	url = https://github.com/appernetic/hugo-bootstrap-premium.git
 [submodule "academic"]
 	path = academic
 	url = https://github.com/gcushen/hugo-academic.git


### PR DESCRIPTION
Reverts gohugoio/hugoThemes#494

Since Hugo 0.52 this theme's demo generates with the Build Script.