### PR TITLE
Add note about relative protocol URLs in theme templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The demo of your theme will be available in a subdirectory of the [Hugo Themes w
 - If using relative URLs in links, these need to be quoted, e.g `<a href="{{ "/blog" | relURL }}">` and `<img src="{{ "/images/logo.png" | relURL }}">`
 - If using inline styles, these need to use absolute URLs, for the linked assets to be served properly, e.g. `<div style="background: url('{{ "images/background.jpg" | absURL }}')">`
 - Make sure not to use a forward slash `/` in the beginning of a `URL`, because it will point to the host root and Hugo will not generate the correct `URL` for the demo's assets.
+- If using external CSS and JS from a CDN, make sure to load these assets over `https`. Please do not use relative protocol URLs in your theme's templates.
 
 ## Testing a theme with the Hugo Themes website Build Script
 


### PR DESCRIPTION
This came up in the Forum today: https://discourse.gohugo.io/t/https-issues-baseurl-issue-hugo-third-party-hosting/15894

To summarize the above link: 
A user ran into problems when trying to configure HTTPS for his website because the [Hugo Universal Theme](https://github.com/devcows/hugo-universal-theme/blob/master/layouts/partials/head.html#L26-L27) loads external CSS with relative protocol links. These URLs load assets through the insecure `http` protocol even when those assets are available under `https`.

This proposed note in the README is not related to Hugo, but in my opinion it would be good to have because external assets must be loaded securely over `https`.