### PR TITLE
Amend Common Permalink Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ If your theme makes use of the [Hugo Pipes](https://gohugo.io/hugo-pipes) method
 
 The demo of your theme will be available in a subdirectory of the [Hugo Themes website](https://themes.gohugo.io/) and you need to make sure of the following:
 
-- If using relative URLs in links, these need to be quoted, e.g `<a href="{{ "/blog" | relURL }}">` and `<img src="{{ "/images/logo.png" | relURL }}">`
 - If using inline styles, these need to use absolute URLs, for the linked assets to be served properly, e.g. `<div style="background: url('{{ "images/background.jpg" | absURL }}')">`
 - Make sure not to use a forward slash `/` in the beginning of a `URL`, because it will point to the host root and Hugo will not generate the correct `URL` for the demo's assets.
 - If using external CSS and JS from a CDN, make sure to load these assets over `https`. Please do not use relative protocol URLs in your theme's templates.


### PR DESCRIPTION
See https://github.com/gohugoio/hugo/issues/5488#issuecomment-449552225

Hugo now supports unquoted URLs in `canonifyURLs` replacer

**EDIT**
@digitalcraftsman We need to wait until the next release of Hugo before this PR is merged. See the following comment: https://github.com/gohugoio/hugoDocs/pull/690#discussion_r243731410

I'll post a reminder when it's due.