### PR TITLE
Temporarily disable CleanWhite Demo

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -116,7 +116,7 @@ blacklist=('persona', 'html5', 'journal', '.git', 'aurora', 'hugo-plus', 'yume',
 # hugo-theme-learn: the theme owner requested the disable of the theme demo, see https://github.com/gohugoio/hugoThemes/issues/172
 # lamp: Icon font does not work with baseURL with sub-folder.
 # hugo-bare-min: The demo throws an ERROR because the Build Script does not support Theme Components at the moment, see https://github.com/gohugoio/hugoThemes/issues/463
-noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'lamp', 'hugo-bare-min-theme')
+noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'lamp', 'hugo-bare-min-theme', 'hugo-theme-cleanwhite')
 
 errorCounter=0
 


### PR DESCRIPTION
This demo has promotional content that does not meet the Hugo website guidelines.
 
I contacted the author and he will take down the content sometime this week or next week.

Until then we need to disable this demo.

Once the theme author fixes the content we can enable the demo again.

See: https://github.com/zhaohuabing/hugo-theme-cleanwhite/issues/25