### PR TITLE
Add note about 3rd party tracking, emphasize note about neutral content etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,15 @@ git clone <em>URL_TO_THEME</em>
 
 If your theme doesn't fit into the `Hugo Basic Example` site, we encourage theme authors to supply a self-contained Hugo site in `/exampleSite`.
 
-**NOTE:** The folder name here is important, as this folder will be picked up and used by the script that generates the Hugo Theme Site. It mirrors the root directory of a Hugo website and allows you to add custom content, assets and a config file with preset values.
+**NOTES** 
 
-**NOTE:** Most of the themes in this repo are hosted on GitHub. We also include themes hosted on GitLab and similar, but we do not add themes living on a self-hosted repository.
+* The folder name here is important, as this folder will be picked up and used by the script that generates the Hugo Theme Site. It mirrors the root directory of a Hugo website and allows you to add custom content, assets and a config file with preset values.
 
-See [Artist theme's exampleSite](https://github.com/digitalcraftsman/hugo-artists-theme/tree/master/exampleSite) for a good example. And please make the site's content as neutral as possible.
+* Most of the themes in this repo are hosted on GitHub. We also include themes hosted on GitLab and similar, but we do not add themes living on a self-hosted repository.
+
+* Please make the Example Site's content as **neutral as possible**. See [Artist theme's exampleSite](https://github.com/digitalcraftsman/hugo-artists-theme/tree/master/exampleSite)
+
+* An Example Site should **not** have third party tracking enabled. If you wish to provide configuration parameters to third party services (analytics, comments etc) then please do not enter a valid account `ID` or username.
 
 Each theme needs:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If your theme doesn't fit into the `Hugo Basic Example` site, we encourage theme
 
 * Most of the themes in this repo are hosted on GitHub. We also include themes hosted on GitLab and similar, but we do not add themes living on a self-hosted repository.
 
-* Please make the Example Site's content as **neutral as possible**. See the [Artist theme's exampleSite](https://github.com/digitalcraftsman/hugo-artists-theme/tree/master/exampleSite) for a good example.
+* Please make the Example Site's content as **neutral as possible**. See the [Artist theme's `/exampleSite/`](https://github.com/digitalcraftsman/hugo-artists-theme/tree/master/exampleSite) for a good example.
 
 * An Example Site should **not** have third party tracking enabled. If you wish to provide configuration parameters to third party services (analytics, comments etc) then please do not enter a valid account `ID` or username.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If your theme doesn't fit into the `Hugo Basic Example` site, we encourage theme
 
 * Most of the themes in this repo are hosted on GitHub. We also include themes hosted on GitLab and similar, but we do not add themes living on a self-hosted repository.
 
-* Please make the Example Site's content as **neutral as possible**. See [Artist theme's exampleSite](https://github.com/digitalcraftsman/hugo-artists-theme/tree/master/exampleSite)
+* Please make the Example Site's content as **neutral as possible**. See the [Artist theme's exampleSite](https://github.com/digitalcraftsman/hugo-artists-theme/tree/master/exampleSite) for a good example.
 
 * An Example Site should **not** have third party tracking enabled. If you wish to provide configuration parameters to third party services (analytics, comments etc) then please do not enter a valid account `ID` or username.
 


### PR DESCRIPTION
See https://github.com/gohugoio/hugoThemes/issues/535#issuecomment-452992047 for the need to add the note about 3rd party tracking.

See https://github.com/zhaohuabing/hugo-theme-cleanwhite/issues/25 for the need to emphasize the note about neutral content.

Also I consolidated the Notes of the *Adding a theme to the list* section under a single sub-heading and inserted bullet points.