### PR TITLE
Remove Simple Hugo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,9 +85,6 @@
 [submodule "startbootstrap-clean-blog"]
 	path = startbootstrap-clean-blog
 	url = https://github.com/humboldtux/startbootstrap-clean-blog.git
-[submodule "simple-hugo"]
-	path = simple-hugo
-	url = https://github.com/druzza/simple-hugo.git
 [submodule "creative"]
 	path = creative
 	url = https://github.com/digitalcraftsman/hugo-creative-theme.git


### PR DESCRIPTION
The [Simple Hugo Theme](https://themes.gohugo.io/simple-hugo/) has been deleted from [GitHub](https://github.com/druzza/simple-hugo).

Also see: https://discourse.gohugo.io/t/git-installing-themes-not-working/16609

cc: @digitalcraftsman 