### PR TITLE
Force Hugo Basic Example contentDir

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -182,7 +182,7 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
             ln -s ${themesDir}/$x/exampleSite ${siteDir}/exampleSite2
             ln -s ${themesDir} ${siteDir}/exampleSite2/themes
             destionation="../themeSite/static/theme/$x/"
-            HUGO_THEME=${x} hugo --quiet -s exampleSite2 -d ${demoDestination} -b $BASEURL/theme/$x/
+            HUGO_THEME=${x} hugo --quiet -s exampleSite2 -c ${siteDir}/exampleSite/content -d ${demoDestination} -b $BASEURL/theme/$x/
             if [ $? -ne 0 ]; then
                 echo "FAILED to create exampleSite for $x"
                 errorCounter=$((errorCounter + 1))

--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -182,7 +182,7 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
             ln -s ${themesDir}/$x/exampleSite ${siteDir}/exampleSite2
             ln -s ${themesDir} ${siteDir}/exampleSite2/themes
             destionation="../themeSite/static/theme/$x/"
-            HUGO_THEME=${x} hugo --quiet -s exampleSite2 -c ${siteDir}/exampleSite/content -d ${demoDestination} -b $BASEURL/theme/$x/
+            HUGO_THEME=${x} hugo --quiet -s exampleSite2 -c ${siteDir}/exampleSite/content/ -d ${demoDestination} -b $BASEURL/theme/$x/
             if [ $? -ne 0 ]; then
                 echo "FAILED to create exampleSite for $x"
                 errorCounter=$((errorCounter + 1))


### PR DESCRIPTION
Closes #546 

This PR forces the Hugo Basic Example content directory in theme demos for the Hugo Themes showcase. We will be losing flexibility but we just cannot keep track of inappropriate content in theme demos.

For more details and examples of past issues see the above linked issue.

---
**EDIT**

The Netlify deploy preview succeeded.

I am asking for reviews from @digitalcraftsman @bep

- If this PR is merged the following 7 theme demos will break because of it. 
- I will task myself with notifying theme authors and assisting them to provide a fix.
- Also I will be looking into updating the content directory of the Hugo Basic Example (like for example to provide headless bundles for the homepage for themes that may need this).
- Also some menu links in existing theme demos that currently rely on custom content pages will be broken.
- However the above is a small price to pay rather than having the risk of someone pushing whatever they please on the Hugo website and us discovering it months later.
- Also the repo README and the theme submission issue template, will need to be updated.

```
11:41:18 PM: ==== PROCESSING strange-case ======
11:41:18 PM: Error: Error building site: failed to render pages: render of "page" failed: "/opt/build/repo/strange-case/layouts/_default/single.html:16:80": execute of template failed: template: _default/single.html:16:80: executing "_default/single.html" at <.Site.Params.datefor...>: invalid value; expected string
11:41:18 PM: FAILED to create demo site for strange-case
11:41:14 PM:  ==== PROCESSING  hugo-mdl  ======
11:41:14 PM: Building site for theme hugo-mdl using its own exampleSite to ../themeSite/static/theme/hugo-mdl/
11:41:14 PM: ERROR 2019/01/28 21:41:14 in .Render: Failed to execute template "post/listitem.html": "/opt/build/repo/hugo-mdl/layouts/post/listitem.html:4:44": execute of template failed: template: post/listitem.html:4:44: executing "post/listitem.html" at <.Params.author.image>: can't evaluate field image in type interface {}
11:41:14 PM: ERROR 2019/01/28 21:41:14 in .Render: Failed to execute template "post/card-8.html": "/opt/build/repo/hugo-mdl/layouts/post/card-8.html:10:40": execute of template failed: template: post/card-8.html:10:40: executing "post/card-8.html" at <.Params.author.image>: can't evaluate field image in type interface {}
11:41:14 PM: Error: Error building site: failed to render pages: render of "page" failed: "/opt/build/repo/hugo-mdl/layouts/post/single.html:8:40": execute of template failed: template: post/single.html:8:40: executing "post/single.html" at <.Params.author.image>: can't evaluate field image in type interface {}
11:41:14 PM: FAILED to create exampleSite for hugo-mdl
11:41:17 PM:  ==== PROCESSING  hugo-resume  ======
11:41:17 PM: Building site for theme hugo-resume using its own exampleSite to ../themeSite/static/theme/hugo-resume/
11:41:17 PM: WARNING: calling IsSet with unsupported type "string" (string) will always return false.
11:41:17 PM: Error: Error building site: failed to render pages: render of "section" failed: "/opt/build/repo/hugo-resume/layouts/_default/section.html:8:11": execute of template failed: template: _default/section.html:8:11: executing "main" at <partial (printf "%s%...>: error calling partial: Partial "postSummary" not found
11:41:17 PM: FAILED to create exampleSite for hugo-resume
11:41:21 PM:  ==== PROCESSING  hugo-hero-theme  ======
11:41:21 PM: Building site for theme hugo-hero-theme using its own exampleSite to ../themeSite/static/theme/hugo-hero-theme/
11:41:21 PM: Error: Error building site: failed to render pages: render of "home" failed: "/opt/build/repo/hugo-hero-theme/layouts/index.html:23:30": execute of template failed: template: index.html:23:30: executing "main" at <$headless.Resources....>: can't evaluate field Resources in type *hugolib.Page
11:41:21 PM: FAILED to create exampleSite for hugo-hero-theme
11:41:45 PM:  ==== PROCESSING  timer-hugo  ======
11:41:45 PM: Building site for theme timer-hugo using its own exampleSite to ../themeSite/static/theme/timer-hugo/
11:41:45 PM: ERROR 2019/01/28 21:41:45 render of "page" failed: "/opt/build/repo/timer-hugo/layouts/_default/single.html:12:31": execute of template failed: template: _default/single.html:12:31: executing "_default/single.html" at <delimit .Params.tags...>: error calling delimit: can't iterate over <nil>
11:41:45 PM: ERROR 2019/01/28 21:41:45 render of "page" failed: "/opt/build/repo/timer-hugo/layouts/_default/single.html:12:31": execute of template failed: template: _default/single.html:12:31: executing "_default/single.html" at <delimit .Params.tags...>: error calling delimit: can't iterate over <nil>
11:41:45 PM: Error: Error building site: failed to render pages: render of "page" failed: "/opt/build/repo/timer-hugo/layouts/_default/single.html:12:31": execute of template failed: template: _default/single.html:12:31: executing "_default/single.html" at <delimit .Params.tags...>: error calling delimit: can't iterate over <nil>
11:41:45 PM: FAILED to create exampleSite for timer-hugo
11:41:50 PM:  ==== PROCESSING  AllinOne  ======
11:41:50 PM: Building site for theme AllinOne using its own exampleSite to ../themeSite/static/theme/AllinOne/
11:41:50 PM: WARN 2019/01/28 21:41:50 Data for key 'series' in path 'AllinOne/series.toml' is overridden by higher precedence data already in the data tree
11:41:50 PM: ERROR 2019/01/28 21:41:50 render of "page" failed: execute of template failed: template: _default/single.html:10:9: executing "header" at <partial "site-navbar...>: error calling partial: "/opt/build/repo/AllinOne/layouts/partials/site-navbar.html:30:48": execute of template failed: template: partials/site-navbar.html:30:48: executing "partials/site-navbar.html" at <substr .URL 1 -1>: error calling substr: start position out of bounds for 0-byte string
11:41:50 PM: ERROR 2019/01/28 21:41:50 render of "page" failed: execute of template failed: template: _default/single.html:10:9: executing "header" at <partial "site-navbar...>: error calling partial: "/opt/build/repo/AllinOne/layouts/partials/site-navbar.html:30:48": execute of template failed: template: partials/site-navbar.html:30:48: executing "partials/site-navbar.html" at <substr .URL 1 -1>: error calling substr: start position out of bounds for 0-byte string
11:41:50 PM: ERROR 2019/01/28 21:41:50 render of "taxonomyTerm" failed: execute of template failed: template: _default/terms.html:10:9: executing "header" at <partial "site-navbar...>: error calling partial: "/opt/build/repo/AllinOne/layouts/partials/site-navbar.html:30:48": execute of template failed: template: partials/site-navbar.html:30:48: executing "partials/site-navbar.html" at <substr .URL 1 -1>: error calling substr: start position out of bounds for 0-byte string
11:41:50 PM: ERROR 2019/01/28 21:41:50 render of "page" failed: execute of template failed: template: _default/single.html:10:9: executing "header" at <partial "site-navbar...>: error calling partial: "/opt/build/repo/AllinOne/layouts/partials/site-navbar.html:30:48": execute of template failed: template: partials/site-navbar.html:30:48: executing "partials/site-navbar.html" at <substr .URL 1 -1>: error calling substr: start position out of bounds for 0-byte string
11:41:50 PM: Error: Error building site: failed to render pages: render of "page" failed: execute of template failed: template: _default/single.html:10:9: executing "header" at <partial "site-navbar...>: error calling partial: "/opt/build/repo/AllinOne/layouts/partials/site-navbar.html:30:48": execute of template failed: template: partials/site-navbar.html:30:48: executing "partials/site-navbar.html" at <substr .URL 1 -1>: error calling substr: start position out of bounds for 0-byte string
11:41:50 PM: FAILED to create exampleSite for AllinOne
11:42:00 PM: ==== PROCESSING minimal-academic ======
11:42:00 PM: ERROR 2019/01/28 21:42:00 render of "page" failed: execute of template failed: template: _default/single.html:4:3: executing "_default/single.html" at <partial "page.html" ...>: error calling partial: execute of template failed: template: partials/page.html:7:7: executing "partials/page.html" at <partial "post.html" ...>: error calling partial: "/opt/build/repo/minimal-academic/layouts/partials/post.html:20:18": execute of template failed: template: partials/post.html:6:9: executing "partials/post.html" at <partial "post_metada...>: error calling partial: "/opt/build/repo/minimal-academic/layouts/partials/post_metadata.html:20:18": execute of template failed: template: partials/post_metadata.html:20:18: executing "partials/post_metadata.html" at <$.Site.GetPage>: error calling GetPage: too many arguments to .Site.GetPage: [taxonomyTerm categories Development]. Use lookups on the form {{ .Site.GetPage "/posts/mypage-md" }}
11:42:01 PM: FAILED to create exampleSite for minimal-academic
```