### PR TITLE
Add whiteList array in Build Script

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -118,6 +118,8 @@ blacklist=('persona', 'html5', 'journal', '.git', 'aurora', 'hugo-plus', 'yume',
 # hugo-bare-min: The demo throws an ERROR because the Build Script does not support Theme Components at the moment, see https://github.com/gohugoio/hugoThemes/issues/463
 noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'lamp', 'hugo-bare-min-theme')
 
+whiteList=('academic')
+
 errorCounter=0
 
 for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -not -path "*_script" | xargs -n1 basename`; do
@@ -182,7 +184,12 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
             ln -s ${themesDir}/$x/exampleSite ${siteDir}/exampleSite2
             ln -s ${themesDir} ${siteDir}/exampleSite2/themes
             destionation="../themeSite/static/theme/$x/"
+            inWhiteList=`echo ${whiteList[*]} | grep -w "$x"`
+            if [ "${inWhiteList}" != "" ]; then
+            HUGO_THEME=${x} hugo --quiet -s exampleSite2 -d ${demoDestination} -b $BASEURL/theme/$x/
+            else 
             HUGO_THEME=${x} hugo --quiet -s exampleSite2 -c ${siteDir}/exampleSite/content/ -d ${demoDestination} -b $BASEURL/theme/$x/
+            fi
             if [ $? -ne 0 ]; then
                 echo "FAILED to create exampleSite for $x"
                 errorCounter=$((errorCounter + 1))


### PR DESCRIPTION
This PR adds a new array for themes whose content directories we trust.

Currently I have whitelisted the Academic Theme's content because since #547 was merged its demo is missing essential content. This is a very popular theme with more than 2,000 stars on GitHub and we need to have its demo published on the Hugo website.

I am asking for reviews from @bep @digitalcraftsman

Also note that more themes can be added to this array at our discretion.

ref: https://github.com/gcushen/hugo-academic/issues/898