### PR TITLE
whiteList reveal-hugo

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -118,7 +118,7 @@ blacklist=('persona', 'html5', 'journal', '.git', 'aurora', 'hugo-plus', 'yume',
 # hugo-bare-min: The demo throws an ERROR because the Build Script does not support Theme Components at the moment, see https://github.com/gohugoio/hugoThemes/issues/463
 noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'lamp', 'hugo-bare-min-theme')
 
-whiteList=('academic')
+whiteList=('academic', 'reveal-hugo')
 
 errorCounter=0
 


### PR DESCRIPTION
Following the merging of #547 the demo of the [Reveal Hugo theme](https://themes.gohugo.io/reveal-hugo/) throws a 404.

This is a special theme for presentations and we need to have its demo on the website.

Adding it to the whiteList of the Build Script fixes the issue.

cc: @dzello