### PR TITLE
Add hugo-dgraph-theme to noDemo array

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -117,7 +117,8 @@ blacklist=('persona', 'html5', 'journal', '.git', 'aurora', 'hugo-plus', 'yume',
 # lamp: Icon font does not work with baseURL with sub-folder.
 # hugo-bare-min: The demo throws an ERROR because the Build Script does not support Theme Components at the moment, see https://github.com/gohugoio/hugoThemes/issues/463
 # hugo-theme-w3css-basic: the theme owner requested the disable of the theme demo, see https://github.com/gohugoio/hugoThemes/issues/555
-noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'lamp', 'hugo-bare-min-theme', 'hugo-theme-w3css-basic')
+# hugo-dgraph-theme: Not meant for out-of-the-box use, see https://github.com/dgraph-io/hugo-dgraph-theme/issues/7#issuecomment-466009569
+noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'lamp', 'hugo-bare-min-theme', 'hugo-theme-w3css-basic', 'hugo-dgraph-theme')
 
 # academic: Popular theme aimed towards academia
 # reveal-hugo: Presentation theme that depends on reveal.js


### PR DESCRIPTION
One of the theme authors indicated that this theme is not meant for out-of-the-box use. They asked for a low maintenance option while keeping this theme in the showcase.

I offered to add the theme in the `noDemo` array of the Build Script so that it doesn't throw errors during deployment.

Also see: https://github.com/dgraph-io/hugo-dgraph-theme/issues/7#issuecomment-466009569

cc: @digitalcraftsman