### PR TITLE
Fix config for HugoBasicExample Demos

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -213,7 +213,7 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
 
         else
 
-            themeConfig="${TMPDIR}config-${x}.toml"
+            themeConfig="${siteDir}/config-${x}.toml"
             baseConfig="${configBase}.toml"
             paramsConfig="${configBaseParams}.toml"
 


### PR DESCRIPTION
This fix is unrelated to the general refactoring since #547 because this issue is from before.

Currently some theme demos without an exampleSite that rely on the HugoBasicExample lack crucial meta data because the Build Script does not read their generated configs.

`${TMPDIR}` in line 216 of the Build Script is an undefined variable. 

I replaced it with `${siteDir}` so that these theme configs can be read properly.

For example currently the [Purehugo Demo](https://themes.gohugo.io/theme/purehugo/) lacks a title and other meta data. 

Once this PR is merged the demo will have the necessary meta tags again.

cc: @digitalcraftsman 