### PR TITLE
Disable French

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -213,7 +213,7 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
 
         else
 
-            themeConfig="${TMPDIR}config-${x}.toml"
+            themeConfig="${siteDir}/config-${x}.toml"
             baseConfig="${configBase}.toml"
             paramsConfig="${configBaseParams}.toml"
 
@@ -229,7 +229,7 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
             cat themeSite/templates/${paramsConfig} >>${themeConfig}
 
             echo "Building site for theme ${x} using config \"${themeConfig}\" to ${demoDestination}"
-            HUGO_THEME=${x} hugo --quiet -s exampleSite --config=${themeConfig} -d ${demoDestination} -b $BASEURL/theme/$x/
+            HUGO_THEME=${x} hugo --quiet -s exampleSite --config=${themeConfig},${taxoConfig} -d ${demoDestination} -b $BASEURL/theme/$x/
             if [ $? -ne 0 ]; then
                 echo "FAILED to create demo site for $x"
                 rm -rf ${demoDestination}


### PR DESCRIPTION
This is the follow-up PR of https://github.com/gohugoio/hugoBasicExample/pull/30

To disable French in the Build Script this PR needs to be merged after the one above.

Basically I am adding the second config in the command that is meant for themes without an exampleSite that rely on the HugoBasicExample and whose first config is generated by the Build Script.

cc: @digitalcraftsman 

