### PR TITLE
Fix exampleSite contentDir check

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -187,17 +187,16 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
         	# Use content and config in exampleSite
             echo "Building site for theme ${x} using its own exampleSite to ${demoDestination}"
 
-            # Hugo should exit with an error code on these ...
-            if [ ! -d "${themesDir}/$x/exampleSite/content" ]; then
-                echo "Example site for theme ${x} missing /content folder"
-                generateDemo=false
-            fi
-
             ln -s ${themesDir}/$x/exampleSite ${siteDir}/exampleSite2
             ln -s ${themesDir} ${siteDir}/exampleSite2/themes
             destionation="../themeSite/static/theme/$x/"
             inWhiteList=`echo ${whiteList[*]} | grep -w "$x"`
             if [ "${inWhiteList}" != "" ]; then
+ # Hugo should exit with an error code on these ...
+            if [ ! -d "${themesDir}/$x/exampleSite/content" ]; then
+                echo "Example site for theme ${x} missing /content folder"
+                generateDemo=false
+            fi
             HUGO_THEME=${x} hugo --quiet -s exampleSite2 -d ${demoDestination} -b $BASEURL/theme/$x/
             else
             HUGO_THEME=${x} hugo --quiet -s exampleSite2 -c ${siteDir}/exampleSite/content/ --config=${demoConfig},${taxoConfig} -d ${demoDestination} -b $BASEURL/theme/$x/

--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -192,7 +192,7 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
             destionation="../themeSite/static/theme/$x/"
             inWhiteList=`echo ${whiteList[*]} | grep -w "$x"`
             if [ "${inWhiteList}" != "" ]; then
- # Hugo should exit with an error code on these ...
+            # Hugo should exit with an error code on these ...
             if [ ! -d "${themesDir}/$x/exampleSite/content" ]; then
                 echo "Example site for theme ${x} missing /content folder"
                 generateDemo=false


### PR DESCRIPTION
Since #547 the `contentDir` is inherited from the HugoBasicExample.

This PR moves the check whether a `contentDir` exists within the `whiteList` condition, so that this check is performed only for themes whose content directories are permitted.

Also this PR fixes the following theme demos that are currently not generating:

- [Infinty Hugo](https://themes.gohugo.io/infinity-hugo/) ref: https://github.com/themefisher/infinity-hugo/issues/2

- [D-Graph]() ref:https://github.com/dgraph-io/hugo-dgraph-theme/issues/7

After this PR is merged I will send a PR to revert commit https://github.com/gohugoio/hugoThemes/commit/57421eda81dbb1dada62af067 so that the D-Graph theme is removed from the `noDemo` array.

cc: @digitalcraftsman 