### PR TITLE
Add file extensions for exampleSite/config

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -177,7 +177,8 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
 	echo "source = \"$repo\"" >>themeSite/content/$x/index.md
 
 	demoDestination="../themeSite/static/theme/$x/"
-	demoConfig="${themesDir}/$x/exampleSite/config.toml"
+	fileExt=$(.{toml,yaml,yml,json})
+	demoConfig="${themesDir}/$x/exampleSite/config${fileExt}"
 	taxoConfig="${siteDir}/exampleSite/configTaxo.toml"
 
 	export HUGO_CANONIFYURLS=true


### PR DESCRIPTION
As we know Hugo supports TOML, YAML and JSON file formats for a project's config.

This PR adds support for multiple file extensions for the `exampleSite/config` by using [Brace Expansion](https://www.gnu.org/software/bash/manual/html_node/Brace-Expansion.html)

Note that making the config file extension agnostic (i.e. simply deleting the TOML extension) would also work in the Build Script, but somehow I prefer not introduce ambiguity and that's why I opted for Brace Expansion.

This PR fixes the following demos: 
- [Hugo Fresh](https://themes.gohugo.io/hugo-fresh/) 
- [YourFolio](https://themes.gohugo.io/yourfolio/)

It should also fix the demo of any other theme in the repo that uses YAML or JSON.

cc: @digitalcraftsman @bep 