### PR TITLE
Make exampleSite/config extension agnostic

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -177,8 +177,7 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
 	echo "source = \"$repo\"" >>themeSite/content/$x/index.md
 
 	demoDestination="../themeSite/static/theme/$x/"
-	fileExt=$(.{toml,yaml,yml,json})
-	demoConfig="${themesDir}/$x/exampleSite/config${fileExt}"
+	demoConfig="${themesDir}/$x/exampleSite/config"
 	taxoConfig="${siteDir}/exampleSite/configTaxo.toml"
 
 	export HUGO_CANONIFYURLS=true


### PR DESCRIPTION
This is a correction/revision of PR #579

Basically commit 5d1e488 didn't really work. The latest production deploy log printed the following error several times: `./generateThemeSite.sh: line 180: .toml: command not found`

The Hugo Fresh and YourFolio demos were fixed because the `.toml` extension was removed in the above PR.

However Brace Expansion in Bash doesn't work as I thought it would in this context.

Therefore simply removing the `.toml` extension from the `exampleSite/config` will get rid of the unneeded Bash error and at the same time all possible config files `(TOML,YAML,YML,JSON)` will be read.

cc: @digitalcraftsman @bep 