### PR TITLE
Add more themes to whiteList

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -130,7 +130,10 @@ noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'lamp', 'hugo
 # hugo-book: e-book theme needs its own content
 # yourfolio: portfolio theme needs its own content
 # hugo-resume: complicated resume theme needs its own content
-whiteList=('academic', 'reveal-hugo', 'hugo-terrassa-theme', 'hugo-theme-learn', 'hugo-now-ui', 'dot-hugo-documentation-theme', 'cupper-hugo-theme', 'hugo-book', 'yourfolio', 'hugo-resume')
+# hugo-mdl: author parameter is an inline table
+# hugo-dream-plus : author parameter is an inline table, also this theme needs its own content 
+# gohugo-theme-ananke: Quick start guide theme
+whiteList=('academic', 'reveal-hugo', 'hugo-terrassa-theme', 'hugo-theme-learn', 'hugo-now-ui', 'dot-hugo-documentation-theme', 'cupper-hugo-theme', 'hugo-book', 'yourfolio', 'hugo-resume', 'hugo-mdl', 'hugo-dream-plus', 'gohugo-theme-ananke')
 
 errorCounter=0
 


### PR DESCRIPTION
Pull Request https://github.com/gohugoio/hugoBasicExample/pull/33 turned the author front matter parameter into an Inline Table to fix the demos of hugo-mdl and hugo-dream-plus. 

Unfortunately the above broke some 12 theme demos.

Therefore I am adding these themes to the whiteList and the author front matter parameter was reverted back to a string in PR https://github.com/gohugoio/hugoBasicExample/pull/36

Also I added the Ananke theme in the whiteList because this is the theme that is used in the official Hugo Quick Start Guide.

cc: @digitalcraftsman 