### PR TITLE
Remove cState theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -644,9 +644,6 @@
 [submodule "hugo-theme-den"]
 	path = hugo-theme-den
 	url = https://github.com/shaform/hugo-theme-den.git
-[submodule "cstate"]
-	path = cstate
-	url = https://github.com/mistermantas/cstate.git
 [submodule "engimo"]
 	path = engimo
 	url = https://github.com/achary/engimo.git


### PR DESCRIPTION
@mistermantas 

This PR is continued from https://github.com/cstate/cstate/issues/59

As stated in the [README](https://github.com/gohugoio/hugoThemes#adding-a-theme-to-the-list) of the Hugo Themes repo:

> Each theme needs:
> To have the right images;

Both @digitalcraftsman and I have decided to remove the cState theme until the screenshot and the thumbnail are fixed; they **have to** reflect the theme demo as it is currently.

Once you do the above do let us know so that we can add your theme back to the Hugo website.