### PR TITLE
Remove d-graph from noDemo array

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -117,8 +117,7 @@ blacklist=('persona', 'html5', 'journal', '.git', 'aurora', 'hugo-plus', 'yume',
 # lamp: Icon font does not work with baseURL with sub-folder.
 # hugo-bare-min: The demo throws an ERROR because the Build Script does not support Theme Components at the moment, see https://github.com/gohugoio/hugoThemes/issues/463
 # hugo-theme-w3css-basic: the theme owner requested the disable of the theme demo, see https://github.com/gohugoio/hugoThemes/issues/555
-# hugo-dgraph-theme: Not meant for out-of-the-box use, see https://github.com/dgraph-io/hugo-dgraph-theme/issues/7#issuecomment-466009569
-noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'lamp', 'hugo-bare-min-theme', 'hugo-theme-w3css-basic', 'hugo-dgraph-theme')
+noDemo=('hugo-incorporated', 'hugo-theme-arch', 'hugo-smpl-theme', 'lamp', 'hugo-bare-min-theme', 'hugo-theme-w3css-basic')
 
 # academic: Popular theme aimed towards academia
 # reveal-hugo: Presentation theme that depends on reveal.js


### PR DESCRIPTION
This PR reverts commit 57421ed

The D-Graph theme authors have responded to my feedback regarding the broken demo and now the issue is resolved.

See: https://github.com/dgraph-io/hugo-dgraph-theme/issues/7

@digitalcraftsman For this PR to take effect, the repo's themes will also need to be updated so that the latest changes from the D-Graph repo are pulled.