### PR TITLE
Fixes

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -211,9 +211,9 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
             else
             if grep -Fq '.Pages "Type" "posts"' ${themesDir}/$x/layouts/index.html; then
             echo "Type posts found"
-            HUGO_THEME=${x} hugo --quiet -s exampleSite2 -c ${siteDir}/exampleSite/content/ --config=${demoConfig},${postsConfig},${taxoConfig} -d ${demoDestination} -b $BASEURL/theme/$x/
+            HUGO_THEME=${x} hugo --quiet -s exampleSite2 -c ${siteDir}/exampleSite/content/ --config=${postsConfig},${demoConfig},${taxoConfig} -d ${demoDestination} -b $BASEURL/theme/$x/
             else
-            HUGO_THEME=${x} hugo --quiet -s exampleSite2 -c ${siteDir}/exampleSite/content/ --config=${ignoreConfig}${demoConfig},${taxoConfig} -d ${demoDestination} -b $BASEURL/theme/$x/
+            HUGO_THEME=${x} hugo --quiet -s exampleSite2 -c ${siteDir}/exampleSite/content/ --config=${ignoreConfig},${demoConfig},${taxoConfig} -d ${demoDestination} -b $BASEURL/theme/$x/
             fi
             fi
             if [ $? -ne 0 ]; then


### PR DESCRIPTION
@digitalcraftsman Once this PR is merged the themes in the repo should also be updated for the Mondrian theme's demo to be fixed.

---

Summary:

This PR fixes the issues that have arisen from #598 

- the Build Script calls a config that contains an `ignoreFiles` setting before an Example Site's config.

- when the `hugo` command is executed the Example Site's config overrides the `ignoreFiles` setting in the first config. 

- however Hugo ignores everything in between identical parameters and as a result several theme demos broke due to missing parameters. 

