### PR TITLE
Build script enhancements targeted at individuals testing their own theme

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -155,6 +155,14 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
 		generateDemo=false
 	fi
 
+	skipEmptySubmodule=false
+	if [ ! -f "${themesDir}/$x/theme.toml" ]; then
+		echo " ==== SKIPPING " $x " (Submodule Empty) ====== "
+		skipEmptySubmodule=true
+	fi
+
+	if ! $skipEmptySubmodule; then
+
 	echo " ==== PROCESSING " $x " ====== "
 
 	mkdir -p themeSite/content/$x
@@ -266,6 +274,8 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
 		fixReadme ${themesDir}/$x/README.md >> themeSite/content/$x/index.md
 	else
 		fixReadme ${themesDir}/$x/readme.md >> themeSite/content/$x/index.md
+	fi
+
 	fi
 
 	if ((errorCounter > 50)); then

--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -107,7 +107,7 @@ fi
 # aurora: https://github.com/coryshaw/hugo-aurora-theme/issues/1
 # hugo-plus: https://github.com/H4tch/hugo-plus/issues/5
 # yume: fails to render site for unknown reason, see https://github.com/gohugoio/hugoThemes/issues/190
-blacklist=('persona', 'html5', 'journal', '.git', 'aurora', 'hugo-plus', 'yume', 'sofya', "hugo-theme-arch")
+blacklist=('persona', 'html5', 'journal', '.git', 'aurora', 'hugo-plus', 'yume', 'sofya', "hugo-theme-arch", ".github")
 
 # hugo-incorporated: too complicated, needs its own
 #   exampleSite: https://github.com/nilproductions/hugo-incorporated/issues/24

--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -205,26 +205,27 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
 
         if [ -d "${themesDir}/$x/exampleSite" ]; then
         	# Use content and config in exampleSite
-            echo "Building site for theme ${x} using its own exampleSite to ${demoDestination}"
-
             ln -s ${themesDir}/$x/exampleSite ${siteDir}/exampleSite2
             ln -s ${themesDir} ${siteDir}/exampleSite2/themes
             destination="../themeSite/static/theme/$x/"
             inWhiteList=`echo ${whiteList[*]} | grep -w "$x"`
             if [ "${inWhiteList}" != "" ]; then
-            # Hugo should exit with an error code on these ...
-            if [ ! -d "${themesDir}/$x/exampleSite/content" ]; then
-                echo "Example site for theme ${x} missing /content folder"
-                generateDemo=false
-            fi
-            HUGO_THEME=${x} hugo --quiet -s exampleSite2 -d ${demoDestination} -b $BASEURL/theme/$x/
+				echo "${x} is whitelisted"
+				echo "Building site for theme ${x} using its own exampleSite to ${demoDestination}"
+				# Hugo should exit with an error code on these ...
+				if [ ! -d "${themesDir}/$x/exampleSite/content" ]; then
+					echo "Example site for theme ${x} missing /content folder"
+					generateDemo=false
+				fi
+            	HUGO_THEME=${x} hugo --quiet -s exampleSite2 -d ${demoDestination} -b $BASEURL/theme/$x/
             else
-            if grep -Fq '.Pages "Type" "posts"' ${themesDir}/$x/layouts/index.html; then
-            echo "Type posts found"
-            HUGO_THEME=${x} hugo --quiet -s exampleSite2 -c ${siteDir}/exampleSite/content/ --config=${postsConfig},${demoConfig},${taxoConfig} -d ${demoDestination} -b $BASEURL/theme/$x/
-            else
-            HUGO_THEME=${x} hugo --quiet -s exampleSite2 -c ${siteDir}/exampleSite/content/ --config=${ignoreConfig},${demoConfig},${taxoConfig} -d ${demoDestination} -b $BASEURL/theme/$x/
-            fi
+				echo "Building site for theme ${x} using default content to ${demoDestination}"
+				if grep -Fq '.Pages "Type" "posts"' ${themesDir}/$x/layouts/index.html; then
+				echo "Type posts found"
+				HUGO_THEME=${x} hugo --quiet -s exampleSite2 -c ${siteDir}/exampleSite/content/ --config=${postsConfig},${demoConfig},${taxoConfig} -d ${demoDestination} -b $BASEURL/theme/$x/
+				else
+				HUGO_THEME=${x} hugo --quiet -s exampleSite2 -c ${siteDir}/exampleSite/content/ --config=${ignoreConfig},${demoConfig},${taxoConfig} -d ${demoDestination} -b $BASEURL/theme/$x/
+				fi
             fi
             if [ $? -ne 0 ]; then
                 echo "FAILED to create exampleSite for $x"


### PR DESCRIPTION
I have made some changes to the themeSite `generateThemeSite.sh` build script.

These are intended to make the experience of testing your theme less overwhelming and add clarity. Currently when someone wants to test their theme build, they run this script and they see a wall of warning and error output and it takes about 1 minute to run through everything. It's hard to tell if there was an error in your theme.

With these modifications they can add their submodule, run the script and should see clear output just for their own theme.

I also improved the logging slightly between themes which are using the default content and themes which are allowed to use their own exampleSite content. I think it will be really important to highlight (and document) this in more detail so theme creators can understand how to shape their demo content better to be compatible with hugoThemes.