### PR TITLE
Processing a theme now also updates its submodules if present

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -204,6 +204,13 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
 
     if $generateDemo; then
 
+        if [ -f "${themesDir}/$x/.gitmodules" ]; then
+            pushd ${themesDir}/$x
+            echo "Updating git submodules for theme $x"
+            git submodule update --init --recursive
+            popd
+        fi
+
         if [ -d "${themesDir}/$x/exampleSite" ]; then
         	# Use content and config in exampleSite
             ln -s ${themesDir}/$x/exampleSite ${siteDir}/exampleSite2


### PR DESCRIPTION
If the current theme being processed should have its demo site built and `.gitmodule` is present initializes and updates all its submodule recursively.

Fixes #607.