### PR TITLE
Bump Hugo version to v0.56.3

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [context.production.environment]
-HUGO_VERSION = "0.55.6"
+HUGO_VERSION = "0.56.3"
 HUGO_ENV = "production"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.55.6"
+HUGO_VERSION = "0.56.3"


### PR DESCRIPTION
This should also fix the broken demo of the Minimage theme due to the fact that the author has already set 0.56 as the minimum theme version (see: https://github.com/d-kusk/minimage/commit/ca98c69f05362f22c7a4ab1aaac96a68535fd467) and currently this repo uses the 0.55x series

ref: #669 

**EDIT**
Netlify log shows: `Finished with 17 errors ...` more broken themes due to this ERROR that shows up in various themes: `Invalid float value:` for `'min_version'` in `theme.toml` I just opened https://github.com/gohugoio/hugo/issues/6168

Let's wait for a bit before merging this Pull Request

cc: @digitalcraftsman 