### PR TITLE
Remove Beg Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,9 +52,6 @@
 [submodule "vienna"]
 	path = vienna
 	url = https://github.com/keichi/vienna.git
-[submodule "beg"]
-	path = beg
-	url = https://github.com/dim0627/hugo_theme_beg.git
 [submodule "hugo-theme-casper"]
 	path = casper
 	url = https://github.com/vjeantet/hugo-theme-casper.git


### PR DESCRIPTION
This theme's demo is broken due to https://github.com/gohugoio/hugoThemes/issues/669#issuecomment-518648215

However the Beg theme is currently unmaintained as stated in https://github.com/dim0627/hugo_theme_beg/blame/master/README.md#L2

cc: @digitalcraftsman 