### PR TITLE
Whitelist slick

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -155,7 +155,7 @@ components=('hugo-bare-min-theme')
 # hugo-creative-portfolio-theme: see https://github.com/gohugoio/hugoThemes/issues/649
 # mero: uses custom pages archive and tags / categories. See https://github.com/gohugoio/hugoThemes/issues/593#issuecomment-505934333
 # khata: uses custom pages archive and tags / categories
-whiteList=('academic', 'reveal-hugo', 'hugo-terrassa-theme', 'hugo-theme-learn', 'hugo-now-ui', 'dot-hugo-documentation-theme', 'cupper-hugo-theme', 'hugo-book', 'yourfolio', 'hugo-resume', 'hugo-mdl', 'hugo-dream-plus', 'gohugo-theme-ananke', 'papercss-hugo-theme', 'hugo-serif-theme', 'hugo-theme-introduction', 'hugo-alabaster-theme', 'docuapi', 'hugo-theme-winning', 'co-op', 'hugo-piercer-theme', 'minimo', 'personal-web', 'kitab', 'kross-hugo-portfolio-template', 'parsa-hugo-personal-blog-theme', 'syna', 'crab', 'hugograyscale', 'hugo-creative-portfolio-theme', 'mero', 'khata')
+whiteList=('academic', 'reveal-hugo', 'hugo-terrassa-theme', 'hugo-theme-learn', 'hugo-now-ui', 'dot-hugo-documentation-theme', 'cupper-hugo-theme', 'hugo-book', 'yourfolio', 'hugo-resume', 'hugo-mdl', 'hugo-dream-plus', 'gohugo-theme-ananke', 'papercss-hugo-theme', 'hugo-serif-theme', 'hugo-theme-introduction', 'hugo-alabaster-theme', 'docuapi', 'hugo-theme-winning', 'co-op', 'hugo-piercer-theme', 'minimo', 'personal-web', 'kitab', 'kross-hugo-portfolio-template', 'parsa-hugo-personal-blog-theme', 'syna', 'crab', 'hugograyscale', 'hugo-creative-portfolio-theme', 'mero', 'khata', 'slick')
 
 errorCounter=0
 


### PR DESCRIPTION
The [Slick theme](https://github.com/spookey/slick) has changed quite a lot since it was submitted to the themes repo back in [Dec 2018](https://github.com/gohugoio/hugoThemes/issues/523)

The author has organized it in a non standard way. For example the `exampleSite` folder is a symlink that points to `/_sites/example` and all sorts of other stuff that cause the ERROR mentioned in #669:

```
4:19:09 PM:  ==== PROCESSING  slick  ======
4:19:09 PM: ln: failed to create symbolic link '/opt/build/repo/_script/hugoThemeSite/exampleSite2/themes/repo': File exists
4:19:09 PM: Building site for theme slick using default content to ../themeSite/static/theme/slick/
4:19:10 PM: ERROR 2019/08/04 13:19:10 render of "taxonomyTerm" failed: "/opt/build/repo/slick/layouts/_default/terms.html:7:16": execute of template failed: template: _default/terms.html:7:16: executing "main" at <$.GetPage>: error calling GetPage: failed to resolve ref: page reference "/tags/markdown" is ambiguous
4:19:10 PM: ERROR 2019/08/04 13:19:10 render of "taxonomyTerm" failed: "/opt/build/repo/slick/layouts/_default/terms.html:7:16": execute of template failed: template: _default/terms.html:7:16: executing "main" at <$.GetPage>: error calling GetPage: failed to resolve ref: page reference "/categories/syntax" is ambiguous
4:19:10 PM: ERROR 2019/08/04 13:19:10 render of "taxonomyTerm" failed: "/opt/build/repo/slick/layouts/_default/terms.html:7:16": execute of template failed: template: _default/terms.html:7:16: executing "main" at <$.GetPage>: error calling GetPage: failed to resolve ref: page reference "/tags/markdown" is ambiguous
4:19:10 PM: Error: Error building site: failed to render pages: render of "taxonomyTerm" failed: "/opt/build/repo/slick/layouts/_default/terms.html:7:16": execute of template failed: template: _default/terms.html:7:16: executing "main" at <$.GetPage>: error calling GetPage: failed to resolve ref: page reference "/categories/syntax" is ambiguous
4:19:10 PM: FAILED to create exampleSite for slick
4:19:10 PM: rm: cannot remove '/opt/build/repo/_script/hugoThemeSite/exampleSite2/themes': Is a directory

```

The non standard customizations of this theme make debugging it beyond the scope of support that I am able to offer. (i.e. I do not have the time).

However I noticed that if this theme is whitelisted in the Build Script then its demo generates hence this PR.

I do think though that we need to establish some rules in the repo. We cannot have really complex themes that do non standard things. But that is not my call. 

@digitalcraftsman if you also think (like I do) that theme authors should stick to the theme organization rules as stated in the README then don't merge this PR. 

Instead when I update the README guidelines for #672 I will open an issue in the theme author's repo notifying him/her/they that the theme has been removed because a theme needs to be organized as instructed and that it should also work with the Build Script and that also we offer instructions for testing locally.
