### PR TITLE
Remove Cocoa theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -121,9 +121,6 @@
 [submodule "gindoro"]
 	path = gindoro
 	url = https://github.com/cdipaolo/gindoro.git
-[submodule "cocoa"]
-	path = cocoa
-	url = https://github.com/nishanths/cocoa-hugo-theme.git
 [submodule "steam"]
 	path = steam
 	url = https://github.com/digitalcraftsman/hugo-steam-theme.git


### PR DESCRIPTION
This theme is no longer maintained as stated in the [description](https://github.com/nishanths/cocoa-hugo-theme) of the theme repo.

cc: @digitalcraftsman 