### PR TITLE
Bump Hugo version to 0.57.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [context.production.environment]
-HUGO_VERSION = "0.57.1"
+HUGO_VERSION = "0.57.2"
 HUGO_ENV = "production"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.57.1"
+HUGO_VERSION = "0.57.2"


### PR DESCRIPTION
This will fix the showcase  since the breaking change for the `homepage` Page collection is reverted until the release of Hugo v.0.58.0.