### PR TITLE
Add detection of Section Posts in build script

### DIFF
--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -263,7 +263,7 @@ for x in `find ${themesDir} -mindepth 1 -maxdepth 1 -type d -not -path "*.git" -
             	HUGO_THEME=${x} hugo --quiet -s exampleSite2 -d ${demoDestination} -b $BASEURL/theme/$x/
             else
                                 grep -v "enableEmoji" ${searchConfig} > temp && mv temp ${searchConfig}
-                                find ${themesDir}/$x/layouts/ -type f -exec sed -i 's/Pages "Type" "posts"/Pages "Type" "post"/g' {} \;
+                                find ${themesDir}/$x/layouts/ -type f -exec sed -i -e 's/Pages "Type" "posts"/Pages "Type" "post"/g' -e 's/Pages "Section" "posts"/Pages "Section" "post"/g' {} \;
 				echo "Building site for theme ${x} using default content to ${demoDestination}"
                                 if [ "${hasCompontents}" != "" ]; then
 				echo "Building site for theme ${x} with Theme Components"


### PR DESCRIPTION
This is continued from #703 due to this https://github.com/bul-ikana/hugo-cards/commit/e3248eff22a6d90f01d8207cceee84075d478580#diff-3db8db7226d7f28bb43b59ce30ad6157R8

Apparently there are themes in the repo that use `where .Site.RegularPages "Section" "posts"`

This commit will make sure that the Build Script will detect the above in a theme's templates and change the `Section` to `post` since that is the only section served by the hugoBasicExample.