### PR TITLE
Re-add and whitelist hugo-changelog-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -755,3 +755,6 @@
 [submodule "colordrop"]
 	path = colordrop
 	url = https://github.com/humrochagf/colordrop
+[submodule "hugo-changelog-theme"]
+	path = hugo-changelog-theme
+	url = https://github.com/jsnjack/hugo-changelog-theme

--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -171,7 +171,8 @@ components=('hugo-bare-min-theme')
 # hugo-theme-robotico 
 # hugo-travelify-theme
 # colordrop: demo is multilingual
-whiteList=('academic', 'reveal-hugo', 'hugo-terrassa-theme', 'hugo-theme-learn', 'hugo-now-ui', 'dot-hugo-documentation-theme', 'cupper-hugo-theme', 'hugo-book', 'yourfolio', 'hugo-resume', 'hugo-mdl', 'hugo-dream-plus', 'gohugo-theme-ananke', 'papercss-hugo-theme', 'hugo-serif-theme', 'hugo-theme-introduction', 'hugo-alabaster-theme', 'docuapi', 'hugo-theme-winning', 'co-op', 'hugo-piercer-theme', 'minimo', 'personal-web', 'kitab', 'kross-hugo-portfolio-template', 'parsa-hugo-personal-blog-theme', 'syna', 'crab', 'hugograyscale', 'hugo-creative-portfolio-theme', 'mero', 'khata', 'OneDly-Theme', 'hugo-webslides', 'hugo-minimalist-spa', 'hugo-theme-den', 'simplicity', 'alpha-church', 'castanet', 'hugo-apps-theme', 'hugo-theme-techdoc', 'hugo-theme-revealjs', 'hugo-theme-robotico', 'hugo-travelify-theme', 'colordrop')
+# hugo-changelog-theme needs its own content to function
+whiteList=('academic', 'reveal-hugo', 'hugo-terrassa-theme', 'hugo-theme-learn', 'hugo-now-ui', 'dot-hugo-documentation-theme', 'cupper-hugo-theme', 'hugo-book', 'yourfolio', 'hugo-resume', 'hugo-mdl', 'hugo-dream-plus', 'gohugo-theme-ananke', 'papercss-hugo-theme', 'hugo-serif-theme', 'hugo-theme-introduction', 'hugo-alabaster-theme', 'docuapi', 'hugo-theme-winning', 'co-op', 'hugo-piercer-theme', 'minimo', 'personal-web', 'kitab', 'kross-hugo-portfolio-template', 'parsa-hugo-personal-blog-theme', 'syna', 'crab', 'hugograyscale', 'hugo-creative-portfolio-theme', 'mero', 'khata', 'OneDly-Theme', 'hugo-webslides', 'hugo-minimalist-spa', 'hugo-theme-den', 'simplicity', 'alpha-church', 'castanet', 'hugo-apps-theme', 'hugo-theme-techdoc', 'hugo-theme-revealjs', 'hugo-theme-robotico', 'hugo-travelify-theme', 'colordrop', 'hugo-changelog-theme')
 
 errorCounter=0
 


### PR DESCRIPTION
This theme was removed due to the empty homepage as part of #682 

However the empty homepage was due to the fact that this theme uses hardcoded sections for its index lists that are not provided by the hugoBasicExample.

Therefore with this PR I am re-adding this theme and adding to the whitelist array of the build script.