### PR TITLE
Bump Hugo version to v.0.59.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [context.production.environment]
-HUGO_VERSION = "0.58.3"
+HUGO_VERSION = "0.59.0"
 HUGO_ENV = "production"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.58.3"
+HUGO_VERSION = "0.59.0"


### PR DESCRIPTION
I sent this Pull Request because I need to see the deploy preview before upgrading to the latest Hugo.

There is a breaking change in Hugo 0.59.0 so I need to see if there are any breaking theme demos:

> Pages.Next/.Prev as described above has existed for a long time, but they have been undocumented. They have been reimplemented for this release and now works like their namesakes on Page. This may be considered a breaking change, but it should be a welcome one, as the old behaviour wasn't very useful

quote is from the [Release Notes of v.0.59.0](https://github.com/gohugoio/hugo/releases/tag/v0.59.0)