### PR TITLE
hugo-apps-theme is transferred

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -522,7 +522,7 @@
 	url = https://github.com/mazgi/hugo-theme-techlog-simple.git
 [submodule "hugo-apps-theme"]
 	path = hugo-apps-theme
-	url = https://github.com/gonapps-org/hugo-apps-theme.git
+	url = https://github.com/gonnux/hugo-apps-theme.git
 [submodule "hugo-serif-theme"]
 	path = hugo-serif-theme
 	url = https://github.com/JugglerX/hugo-serif-theme.git


### PR DESCRIPTION
Hello, thanks for your hard works.
My hugo-apps-theme repository is transferred
from [github.com/gonapps-org/hugo-apps-theme](github.com/gonapps-org/hugo-apps-theme) to [github.com/gonnux/hugo-apps-theme](github.com/gonnux/hugo-apps-theme)
So I updated the submodule url in .gitmodules