### PR TITLE
Add shell script for quick theme reviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 hugoThemeSite/
 _script/*.txt
+_script/review

--- a/README.md
+++ b/README.md
@@ -190,8 +190,9 @@ Themes are updated automatically at:
 
 To test your theme with the Hugo Themes Site Build Script locally:
 - Clone this repo
-- Add your theme from the root of the cloned repo with: `git submodule add <URL of your theme's repo>`
 - Navigate to the `_script/` directory e.g.`cd _script/`
-- Then execute: `./generateThemeSite.sh http://localhost:1313 && hugo server -w=false -s hugoThemeSite/themeSite`
-- Open `localhost:1313` in your browser and navigate to the theme.
+- Then execute: `./reviewTheme.sh <url-to-git-repository-of-theme>
+   - If a theme demo requires its own content structure to function or if it is meant for a specialist use case, whitelist it in [_script/generateThemeSite.sh](https://github.com/gohugoio/hugoThemes/blob/master/_script/generateThemeSite.sh)
+   - More information [here](https://github.com/gohugoio/hugoThemes/tree/master/_script/README.md#quick-build-for-theme-reviews--tests)
+- Open `localhost:1313` in your browser and navigate to the theme
 - If your theme demo is not generated you can create an error report with: `./generateThemeSite.sh > errors.txt`

--- a/_script/README.md
+++ b/_script/README.md
@@ -1,30 +1,56 @@
-# hugoThemeSiteScript
-Script to generate Hugo's Theme Site
+# How to generate Hugo's theme site
+
+This document describes how to generate the Hugo theme site for different scenarios.
+
+## Complete build
+
+This script generates Hugo's theme site (as on [www.themes.gohugo.io](https://themes.gohugo.io/))
+by downloading all added themes.
+
+**Note:** Takes a long time and is requires a lot of disk space.
 
 To test it locally, add the root of the baseUrl as first argument:
 
-```
+```bash
 ./generateThemeSite.sh http://localhost:1313
 ```
+
+## Quick build for theme reviews / tests
+
+To test a single theme use the `reviewTheme.sh` script. It uses a dedicated 
+directory to store themes used to build Hugo's theme site. Thus, build time 
+decreases significantly. By default, `./review` is used.
+
+To test it locally, add the url to the Git repository that contains the to be
+tested theme. **Optionally**, change the dedicated directory with flag `-t`.
+
+Whitelist your theme in `./generateThemeSite.sh` if necessary.
+
+```bash
+./reviewTheme.sh <repo> -t <path>
+```
+
+Hugo's theme site will be served automatically at [http://localhost:1313](http://localhost:1313).
+
+## Environment variables
 
 To alter the Hugo themes repository used (contains all themes to display),
 provide a value for the environment variable `HUGO_THEMES_REPO`.
 
-```
+```bash
 HUGO_THEMES_REPO=<repo> ./generateThemeSite.sh http://localhost:1313
 ```
 
 To alter the Hugo theme site repository used, provide a value for the
 environment variable `HUGO_THEME_SITE_REPO`.
 
-```
+```bash
 HUGO_THEME_SITE_REPO=<repo> ./generateThemeSite.sh http://localhost:1313
 ```
 
 To alter the Hugo example site repository used, provide a value for the
 environment variable `HUGO_EXAMPLE_SITE_REPO`.
 
-```
+```bash
 HUGO_EXAMPLE_SITE_REPO=<repo> ./generateThemeSite.sh http://localhost:1313
 ```
-

--- a/_script/generateThemeSite.sh
+++ b/_script/generateThemeSite.sh
@@ -42,15 +42,15 @@ popd() {
 # Load the repositories from the provided environment variables or our defaults
 HUGO_THEME_SITE_REPO=${HUGO_THEME_SITE_REPO:-https://github.com/gohugoio/hugoThemesSite.git}
 HUGO_BASIC_EXAMPLE_REPO=${HUGO_BASIC_EXAMPLE_REPO:-https://github.com/gohugoio/hugoBasicExample.git}
-#HUGO_THEMES_REPO=${HUGO_THEMES_REPO:-https://github.com/gohugoio/hugoThemes.git}
 
-#echo "Using ${HUGO_THEMES_REPO} for themes"
 echo "Using ${HUGO_THEME_SITE_REPO} for theme site"
 echo "Using ${HUGO_BASIC_EXAMPLE_REPO} for example site"
 
 GLOBIGNORE=.*
 siteDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/hugoThemeSite"
-themesDir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# use HUGO_THEMES_REPO to specify alternative location as source for themes. Intended to speed up
+# build times for theme submission reviews by ignoring already added themes.
+themesDir=${HUGO_THEMES_REPO:-"$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"}
 
 echo "Using themes dir ${themesDir}"
 echo "Using site dir ${siteDir}"

--- a/_script/reviewTheme.sh
+++ b/_script/reviewTheme.sh
@@ -1,0 +1,48 @@
+# /bin/bash
+
+# exit immediately if one the following commands throws an error
+set -e
+
+function help () {
+    echo -ne  "This script is intended for quick theme reviews. The theme will be cloned into a dedicated directory if not already done. Themes already added to the theme site are ignored, thus total build time decreases. On success, the theme site will be served using the \"hugo server\" command.
+
+Usage:
+
+${BASH_SOURCE[0]} URL-TO-GIT-REPOSITORY [arguments]
+
+Flags:
+
+  -t    dedicated directory to clone theme to. Default is $scriptDir/review\n"
+}
+
+repoUrl=$1
+# location of this script
+scriptDir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# define location to clone theme to
+themesDir="$scriptDir/review"
+
+if [ $# -eq 0 ]; then
+    echo -ne "Please provide a url to a Git repository containing the theme as the first argument, e.g. https://github.com/user/theme-name.git\n\n"
+    help; exit 1
+fi
+
+
+# skip first argument (repoUrl)
+OPTIND=2
+while getopts ":t:" opt; do
+    case $opt in
+        t) themesDir=$OPTARG;;
+        *) echo -ne "Unknown argument -$OPTARG provided.\n\n"; help; exit 1;;
+    esac
+done
+
+
+cloneDest="$themesDir/$(basename $repoUrl .git)"
+if [ ! -d $cloneDest ]; then
+  git clone --recursive $repoUrl $cloneDest
+fi
+
+# expose themesDir to generateThemeSite.sh
+export HUGO_THEMES_REPO=$themesDir
+# generate theme site and start hugo server.
+"$scriptDir/generateThemeSite.sh" "http://localhost:1313" && hugo server -w=false -s hugoThemeSite/themeSite


### PR DESCRIPTION
This shell script builds the theme site by using a dedicated directory DIR to store themes. The to be reviewed theme will be cloned to DIR if not already done. Themes already added to the theme site will be ignored, thus total build time decreases. On success, the theme site will be served using the "hugo server" command.

See _script/reviewTheme.sh for more information.