### PR TITLE
Repo URL for `academic` theme updated

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -75,7 +75,7 @@
 	url = https://github.com/matcornic/hugo-theme-learn.git
 [submodule "academic"]
 	path = academic
-	url = https://github.com/gcushen/hugo-academic.git
+	url = https://github.com/wowchemy/starter-academic.git
 [submodule "hugo-lithium-theme"]
 	path = hugo-lithium-theme
 	url = https://github.com/jrutheiser/hugo-lithium-theme.git


### PR DESCRIPTION
Hello guys

My `academic` repository has changed location from `github.com/gcushen/hugo-academic` to github.com/wowchemy/starter-academic 

Please can you kindly review and merge the PR - I have updated the corresponding submodule url in `.gitmodules` to reflect the change.

Keep up the awesome work 🙌

Thanks 🙏

George